### PR TITLE
Added pre-commit to nix flake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,8 @@ repos:
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
+
+  - repo: https://github.com/nix-community/nixpkgs-fmt
+    rev: v1.3.0
+    hooks:
+      - id: nixpkgs-fmt

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           buildInputs = (with p.native; [
             protobuf
             nixpkgs-fmt
+            pre-commit
 
             # This is missing on mac m1 nix, for some reason.
             # see https://stackoverflow.com/a/69732679


### PR DESCRIPTION
There are ways to get the nix shell to also invoke pre-commit, but I didn't think it was worth the complexity. I don't intend to run pre-commit automatically anyway, but at least this helps improve the experience for nix users.