### PR TITLE
memfault: main & security mcu to report diagnostic

### DIFF
--- a/messages/mcu_messaging_common.options
+++ b/messages/mcu_messaging_common.options
@@ -1,2 +1,3 @@
 FirmwareUpdateData.image_block max_size: 39
 Log.log max_length: 50
+MemfaultEvent.chunk max_size: 50

--- a/messages/mcu_messaging_common.proto
+++ b/messages/mcu_messaging_common.proto
@@ -216,3 +216,10 @@ message Versions
     FirmwareVersion primary_app = 1;
     FirmwareVersion secondary_app = 2;
 }
+
+message MemfaultEvent
+{
+    // chunk must be sent to the Memfault backend in order
+    uint32 counter = 1;
+    bytes chunk = 2;
+}

--- a/messages/mcu_messaging_main.proto
+++ b/messages/mcu_messaging_main.proto
@@ -113,6 +113,7 @@ message McuToJetson
         BatteryInfoMaxValues battery_info_max_values = 25;
         BatteryInfoSocAndStatistics battery_info_soc_and_statistics = 26;
         ConePresent cone_present = 27;
+        MemfaultEvent memfault_event = 28;
     }
 }
 

--- a/messages/mcu_messaging_sec.proto
+++ b/messages/mcu_messaging_sec.proto
@@ -50,6 +50,7 @@ message SecToJetson
         private.TamperRaw tamper_raw = 9;
         private.TamperStates tamper_states = 10;
         Temperature temperature = 11;
+        MemfaultEvent memfault_event = 12;
     }
 }
 


### PR DESCRIPTION
using the memfault SDK, we only need to relay raw data to their backend