### PR TITLE
cargo: change to version 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "orb-messages"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-messages"
-version = "0.3.0"
+version = "0.0.0"
 description = "Protobuf messages between the jetson and the mcus"
 authors = ["Cyril Fougeray <cyril.fougeray@toolsforhumanity.com>"]
 publish = false


### PR DESCRIPTION
There is no point versioning this library given that we consume it via git revisions anyway. And what matters is that the protobufs are stable, not that the rust code never introduces breaking changes.