### PR TITLE
feat: add new opaque tamper message

### DIFF
--- a/messages/sec.options
+++ b/messages/sec.options
@@ -1,1 +1,2 @@
 orb.mcu.sec.SERequest.data max_size: 512
+orb.mcu.sec.Tamper.unencrypted_json max_size: 640

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -77,5 +77,5 @@ message Tamper {
     /// json is instead done at run time by other software.
     // NOTE: in proto3, all fields are implicitly optional. But we mark it
     // explicitly here just to be extra clear.
-    optional string unencrypted_json = 1 [(nanopb).max_size = 640];
+    optional string unencrypted_json = 1;
 }

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package orb.mcu.sec;
 
-import "nanopb.proto";
 import "common.proto";
 import "sec_priv.proto";
 

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -76,5 +76,5 @@ message Tamper {
     /// json is instead done at run time by other software.
     // NOTE: in proto3, all fields are implicitly optional. But we mark it
     // explicitly here just to be extra clear.
-    optional string opaque_json = 1;
+    optional string unencrypted_json = 1 [(nanopb).max_size = 640];
 }

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package orb.mcu.sec;
 
+import "nanopb.proto";
 import "common.proto";
 import "sec_priv.proto";
 

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -38,14 +38,15 @@ message SecToJetson
         orb.mcu.Versions versions = 2;
         orb.mcu.Log log = 3;
         orb.mcu.sec.SEResponse se_response = 4;
-        orb.mcu.sec.private.Tamper tampered = 5;
+        orb.mcu.sec.private.Tamper tampered = 5 [deprecated = true];
         orb.mcu.BatteryStatus battery_status = 7;
         orb.mcu.FatalError fatal_error = 8;
-        orb.mcu.sec.private.TamperRaw tamper_raw = 9;
-        orb.mcu.sec.private.TamperStates tamper_states = 10;
+        orb.mcu.sec.private.TamperRaw tamper_raw = 9 [deprecated = true];
+        orb.mcu.sec.private.TamperStates tamper_states = 10 [deprecated = true];
         orb.mcu.Temperature temperature = 11;
         orb.mcu.MemfaultEvent memfault_event = 12;
         orb.mcu.HardwareDiagnostic hardware_diag = 13;
+        orb.mcu.sec.Tamper tamper = 14;
     }
 }
 
@@ -67,4 +68,13 @@ message SEResponse
     uint32 id = 1;
     int32 error_code = 2;
     bytes data = 3;
+}
+
+message Tamper {
+    /// Contains tamper information serialized as json. It is "opaque" because
+    /// the schema of the json is not known by orb-messages. Inspecting the
+    /// json is instead done at run time by other software.
+    // NOTE: in proto3, all fields are implicitly optional. But we mark it
+    // explicitly here just to be extra clear.
+    optional string opaque_json = 1;
 }


### PR DESCRIPTION
This PR deprecates the old tamper messages and introduces a new one. The payload will be a `string` and is opaque to the protobufs. Instead, the contents of the string will be deserialized at runtime by other software.