### PR TITLE
chore: make private module's stubs publicly accessible

### DIFF
--- a/src/mcu_sec.rs
+++ b/src/mcu_sec.rs
@@ -2,6 +2,6 @@
 
 include!(concat!(env!("OUT_DIR"), "/mcu_messaging_sec.rs"));
 
-pub(super) mod private {
+pub mod private {
     include!(concat!(env!("OUT_DIR"), "/private.rs"));
 }


### PR DESCRIPTION
Necessary for tamper message support in orb-tamper-engine