### PR TITLE
fix(mcu-message): size must be known at compile time

### DIFF
--- a/messages/sec.options
+++ b/messages/sec.options
@@ -1,2 +1,3 @@
 orb.mcu.sec.SERequest.data max_size: 512
+orb.mcu.sec.SEResponse.data max_size: 512
 orb.mcu.sec.Tamper.unencrypted_json max_size: 640


### PR DESCRIPTION
set SEResponse.data max size to 512 so that the maximum mcu message size
 is known at compile time

this will fix https://github.com/worldcoin/priv-orb-firmware/actions/runs/12758066458/job/35559570433?pr=559 and https://github.com/worldcoin/orb-firmware/pull/149
cc @sri9311 