### PR TITLE
feat: add unencrypted_cbor to tamper message and make oneof

### DIFF
--- a/messages/sec.options
+++ b/messages/sec.options
@@ -1,3 +1,3 @@
 orb.mcu.sec.SERequest.data max_size: 512
 orb.mcu.sec.SEResponse.data max_size: 512
-orb.mcu.sec.Tamper.unencrypted_json max_size: 640
+orb.mcu.sec.Tamper.unencrypted_cbor max_size: 512

--- a/messages/sec.proto
+++ b/messages/sec.proto
@@ -70,11 +70,13 @@ message SEResponse
     bytes data = 3;
 }
 
+/// Contains tamper information serialized in a self-describing format. It is
+/// "opaque" because the schema of the tamper message is not known by orb-messages.
+/// Inspecting the tamper message is instead done at runtime by other software.
 message Tamper {
-    /// Contains tamper information serialized as json. It is "opaque" because
-    /// the schema of the json is not known by orb-messages. Inspecting the
-    /// json is instead done at run time by other software.
-    // NOTE: in proto3, all fields are implicitly optional. But we mark it
-    // explicitly here just to be extra clear.
-    optional string unencrypted_json = 1;
+    oneof payload { 
+        /// Note: these are *not* minified, they are still using string based
+        /// identifiers for fields.
+        bytes unencrypted_cbor = 1;
+    }
 }


### PR DESCRIPTION
now, it will be a `oneof` instead of a regular message. And i've added the `unencrypted_cbor` field to it.