### PR TITLE
chore(tamper_cbor): reduce CBOR max size

### DIFF
--- a/messages/sec.options
+++ b/messages/sec.options
@@ -1,3 +1,3 @@
 orb.mcu.sec.SERequest.data max_size: 512
 orb.mcu.sec.SEResponse.data max_size: 512
-orb.mcu.sec.Tamper.unencrypted_cbor max_size: 512
+orb.mcu.sec.Tamper.unencrypted_cbor max_size: 58


### PR DESCRIPTION
Reduce the payload size since only one sensor needs to fit