### PR TITLE
feat(reboot): command to fully reboot the orb

### DIFF
--- a/messages/common.proto
+++ b/messages/common.proto
@@ -26,9 +26,12 @@ message Ack
     ErrorCode error = 2;
 }
 
-// Note: if a new firmware image has been loaded in the microcontroller's
-// secondary slot, the bootloader will try to update the application. In
-// this particular case, the Jetson will be turned off.
+// Reboot the microcontroller with a delay (seconds)
+// With main mcu, the Jetson is turned off as long as the main mcu is waiting
+// for a button press. See RebootOrb to fully reboot the Orb with a command.
+//
+// Note: if a new firmware image has been installed by the bootlader, the app
+// will also boot the Jetson
 message RebootWithDelay
 {
     uint32 delay = 1; // [0...60] seconds

--- a/messages/main.proto
+++ b/messages/main.proto
@@ -14,7 +14,7 @@ message JetsonToMcu
 
     oneof payload
     {
-        ShutdownWithDelay shutdown = 2;
+        ShutdownWithDelay shutdown = 2 [ deprecated = true ]; // never used
         orb.mcu.RebootWithDelay reboot = 3;
         orb.mcu.Temperature temperature = 4;
         MirrorAngle mirror_angle = 5;
@@ -63,6 +63,7 @@ message JetsonToMcu
         Polarizer polarizer = 48;
         PowerCycle power_cycle = 49;
         orb.mcu.Time set_time = 50;
+        RebootOrb reboot_orb = 51;
     }
 }
 
@@ -127,6 +128,17 @@ message InfraredLEDs
 message ShutdownWithDelay
 {
     uint32 delay_s = 1; // [0...30] seconds
+}
+
+// Reboot the orb, ie, the main mcu *and* jetson.
+// Reboot can be forced after `force_reboot_timeout_s` seconds, but a
+// shutdown request from the Jetson is preferred (SHUTDOWN_REQ gpio).
+// This message should be sent **along with** shutting down properly the
+// Jetson, in any case.
+message RebootOrb
+{
+    uint32 force_reboot_timeout_s =
+        1; // [10...60] seconds or 0 to disable force-reboot
 }
 
 message StartTriggeringIrEyeCamera {}


### PR DESCRIPTION
- user should make sure the jetson is shut down properly once this command is sent with `shutdown now` or equivalent
- an option to force reboot is available by passing a delay in seconds (10 to 60), when passing `0` the mcu waits for jetson to shutdown.
