### PR TITLE
feat(main): add RebootSecurityMcu message

### DIFF
--- a/messages/main.proto
+++ b/messages/main.proto
@@ -69,6 +69,7 @@ message JetsonToMcu
         StopTriggeringRgbFaceCamera stop_triggering_rgb_face_camera = 54;
         PolarizerWheelSettings polarizer_wheel_settings = 55;
         SetConfig set_config = 56;
+        RebootSecurityMcu reboot_security_mcu = 57;
     }
 }
 
@@ -170,6 +171,10 @@ message SetConfig
 
 // Indicate to the MCU that the Jetson has completed its boot process
 message BootComplete {}
+
+// Request the main MCU to signal the security MCU to reboot itself
+// Diamond only
+message RebootSecurityMcu {}
 
 message StartTriggeringIrEyeCamera {}
 message StopTriggeringIrEyeCamera {}


### PR DESCRIPTION
Add empty RebootSecurityMcu message to allow the Jetson/CLI to request a security MCU reboot via the main MCU.